### PR TITLE
Add logic to support search for split keywords in patient's response

### DIFF
--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -79,7 +79,7 @@ def search_keywords(
 
 
 def matches_criteria(
-    nlp: spacy.load,
+    nlp: spacy.language.Language,
     response_dict: Mapping[str, str],
     keywords_dict: Mapping[str, List[Union[str, tuple]]],
 ) -> bool:

--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -138,7 +138,7 @@ def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
                             ...
                         }
                     }
-    =
+
         Returns:
             np.ndarray: Input array where rows represent each patient, and columns
                 represent each input (i.e. question). Inputs are as follows:

--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -132,6 +132,10 @@ def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
                                         multiple_words_to_match=True)
         ])
 
+        # Flag 2: Loss of consciousness immediately after urination
+        # or defacation
+        # Removed due to lack of data
+
         # Flag 3: Fall or slump with loss of awareness
         # during event
         input_array[idx,

--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -48,11 +48,11 @@ def search_keywords(
     keywords_list: List[Union[str, tuple]],
 ) -> Union[bool, None]:
     """Determines if any keywords exist in a list of words.
-    Takes a list of words derived from a patient's response/s and
-    and searches for specific keywords.
 
-    In some instances, multiple keywords are required to determine
-    a match, e.g. "black" and "out" in the instance of "black out".
+    Takes a list of words derived from a patient's response/s and searches
+    for specific keywords. In some instances, multiple keywords are
+    required to determine a match, e.g. "black" and "out" in the instance
+    of "black out".
 
     Args:
         response_list: List of words derived from a patient's response/s.
@@ -83,30 +83,32 @@ def matches_criteria(
     response_dict: Mapping[str, str],
     keywords_dict: Mapping[str, List[Union[str, tuple]]],
 ) -> bool:
-    """Determines if a patient's reponse/s fills given criteria for a particular input.
+    """Determines if patient reponses fill given criteria for a particular input.
+
     Takes dict of a patient's responses and returns True if a patient
     matches a given set of criteria, and False if the patient does not match a
     given set of criteria.
 
     Args:
-    response_dict: A patient's responses to a set of questions. Key-value pairs
-    represent questions and responses.
-        Example: {
-            "Question 1": "Response 1",
-            "Question 2": "Response 2",
-            ...
-        }
-    keywords_dict: A set of criteria required for a given input. Key-value pairs
-    represent an input's criteria category and criteria keywords. The criteria
-    category, e.g. "before" is used to determine which questions from the list of
-    available questions is relevant.
-        Example: {
-            "before": ["toilet", "restroom"],
-            "during": ["conscious", "fall", "aware", "faint", "blackout", ("black", "out")]}
+        response_dict: A patient's responses to a set of questions. Key-value pairs
+            represent questions and responses.
+            Example: {
+                "Question 1": "Response 1",
+                "Question 2": "Response 2",
+                ...
+            }
+        keywords_dict: A set of criteria required for a given input. Key-value pairs
+            represent an input's criteria category and criteria keywords. The criteria
+            category, e.g. "before" is used to determine which questions from the list of
+            available questions is relevant.
+            Example: {
+                "before": ["toilet", "restroom"],
+                "during": ["conscious", "fall", "aware", "faint", "blackout", ("black", "out")]
+                }
 
     Returns:
         bool: Returns True if all criteria is matched, elif False if no criteria
-        is matched, else None if no relevant questions are answered.
+            is matched, else None if no relevant questions are answered.
     """
 
     matched_criteria = []
@@ -138,8 +140,8 @@ def matches_criteria(
 
 
 def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
-    """Takes dictionary of patient's responses to survey questions
-    and transforms to One Hot Encoded matrix."
+    """Takes dictionary of patient responses and generates a
+    One Hot Encoded matrix."
 
         Args:
             input_dict (dict): Dictionary where keys represent a patient,
@@ -155,37 +157,38 @@ def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
                     }
         Returns:
             np.ndarray: Input array where rows represent each patient, and columns
-                represent each input (i.e. question). Inputs are as follows:
-                    input_1 - Did skin turn pale before event?
-                    input_2 - Before event included urination or defacation, AND event included loss of
+                represent each input (i.e. question).
+                Inputs are as follows:
+                    Input 1 - Did skin turn pale before event?
+                    Input 2 - Before event included urination or defacation, AND event included loss of
                                 consciousness.
-                    input_3 - Event duration was < 10 sec, AND event included loss of awareness and
+                    Input 3 - Event duration was < 10 sec, AND event included loss of awareness and
                                 fall / slump
-                    input_4 - Event duration was > 10 min, AND event included eyes closed
-                    input_5 - Before event included severe headache
-                    input 6 - Before event included standing up OR sit up OR posture change OR coughing
+                    Input 4 - Event duration was > 10 min, AND event included eyes closed
+                    Input 5 - Before event included severe headache
+                    Input 6 - Before event included standing up OR sit up OR posture change OR coughing
                                 OR pain, AND event included falling
-                    input_7 - Has grey matter lesion (via imaging)
-                    input_8 - Event included lip smacking OR chewing
-                    input_9 - Events are nocturnal-only
-                    input_10 - Onset >= 21 y.o.
-                    input_11 - Event duration < 20 sec, AND event included staring OR blank OR unresponsive
+                    Input 7 - Has grey matter lesion (via imaging)
+                    Input 8 - Event included lip smacking OR chewing
+                    Input 9 - Events are nocturnal-only
+                    Input 10 - Onset >= 21 y.o.
+                    Input 11 - Event duration < 20 sec, AND event included staring OR blank OR unresponsive
                                 OR unaware, AND after event did not include confusion
-                    input_12 - Before event excluded resting NOR sleeping AND event included jerks
-                    input_13 - Before event included waking w/in 1 hr OR jerking AND event included
+                    Input 12 - Before event excluded resting NOR sleeping AND event included jerks
+                    Input 13 - Before event included waking w/in 1 hr OR jerking AND event included
                                 convulsions on both sides, stiffening, jerks
 
                     Elements are represented as NaN = no data, 0 = 'no', or 1 = 'yes'.
-                    Example:
-                        # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
-                        # | flag_1 | flag_2 | flag_3 | flag_4 | flag_5 | flag_6 | lesion | lips | night_seizures | onset_21 | staring | jerks | tonic_clonic |
-                        # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
-                        # | NaN    | NaN    | NaN    | NaN    | NaN    | NaN    | 1      | 0    | 0              | 0        | 0       | 0     | 0            |
-                        # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
-                        # | 1      | 1      | 1      | 0      | 0      | 0      | 1      | 0    | 0              | 0        | 0       | 0     | 0            |
-                        # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
-                        # | 1      | 1      | 1      | 0      | 0      | 0      | 0      | 0    | 0              | 0        | 1       | 1     | 0            |
-                        # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
+                Example:
+                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
+                    # | flag_1 | flag_2 | flag_3 | flag_4 | flag_5 | flag_6 | lesion | lips | night_seizures | onset_21 | staring | jerks | tonic_clonic |
+                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
+                    # | NaN    | NaN    | NaN    | NaN    | NaN    | NaN    | 1      | 0    | 0              | 0        | 0       | 0     | 0            |
+                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
+                    # | 1      | 1      | 1      | 0      | 0      | 0      | 1      | 0    | 0              | 0        | 0       | 0     | 0            |
+                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
+                    # | 1      | 1      | 1      | 0      | 0      | 0      | 0      | 0    | 0              | 0        | 1       | 1     | 0            |
+                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
     """
 
     nlp = spacy.load("en_core_web_sm")

--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -117,7 +117,7 @@ def matches_criteria(
     for criteria, keywords_list in keywords_dict.items():
         relevant_questions = QUESTIONS_DICT[criteria]
         relevant_responses = {
-            k: v for (k, v) in response_dict.items() if k in relevant_questions
+            k: v for k, v in response_dict.items() if k in relevant_questions
         }
 
         if not any(relevant_responses.values()):

--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -11,6 +11,7 @@ BEFORE_EVENT_QUESTIONS = [
     'What other things do you experience right before or at the beginning of a seizure?',
     'Please describe what you feel right before or at the beginning of a seizure.',
     'Please specify other warning.'
+    'Which warnings do you get before you have a seizure?'
 ]
 DURING_EVENT_QUESTIONS = [
     'Please specify other symptoms.',
@@ -18,14 +19,16 @@ DURING_EVENT_QUESTIONS = [
 ]
 DURATION_QUESTIONS = ['How long do your seizures last?']
 
-FLAG_1_KEYWORDS = ['pale', 'white', 'dizzy',
-                   'dissy']  # TODO: add light + head, vertigo multichoice
+FLAG_1_KEYWORDS = ['pale', 'white', 'dizzy', 'dissy', 'vertigo']
+FLAG_1_KEYWORDS_MULTIPLE = ['light', 'head']
+
 FLAG_3_KEYWORDS = ['collapse', 'droop', 'slump']
 FLAG_4_KEYWORDS_DURING = ['eye', 'close', 'shut']
 FLAG_4_KEYWORDS_DURATION = [
     '7 - 15 minutes', 'more than 15 minutes'
 ]  # TODO: check with MCPV team that format is in str
-FLAG_5_KEYWORDS = ['headache', 'migraine']  # TODO: add head + ache
+FLAG_5_KEYWORDS = ['headache', 'migraine']
+FLAG_5_KEYWORDS_MULTIPLE = ['head', 'ache']
 FLAG_6_KEYWORDS_BEFORE = ['pain', 'cough', 'stand']
 FLAG_6_KEYWORDS_DURING = ['fell', 'fall']
 
@@ -37,8 +40,11 @@ class InputFilter:
     def __init__(self, patient_dict):
         self.patient_dict = patient_dict
 
-    def get_flag_value(self, list_of_keys: List[str],
-                       list_of_keywords: List[str]) -> Optional[bool]:
+    def get_flag_value(
+            self,
+            list_of_keys: List[str],
+            list_of_keywords: List[str],
+            multiple_words_to_match: bool = False) -> Optional[bool]:
         # Filter the patient dict of keys (questions) and values (answers)
         input_dict = {key: self.patient_dict[key] for key in list_of_keys}
 
@@ -51,8 +57,12 @@ class InputFilter:
         split_words_doc = list(self.nlp(input_sentences))
         split_words_str = set([token.text for token in split_words_doc])
 
-        return any(keyword for keyword in list_of_keywords
-                   if keyword in split_words_str)
+        if not multiple_words_to_match:
+            return any(keyword for keyword in list_of_keywords
+                       if keyword in split_words_str)
+        else:
+            return all(keyword for keyword in list_of_keywords
+                       if keyword in split_words_str)
 
 
 def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
@@ -114,9 +124,14 @@ def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
 
         filter_input = InputFilter(patient_dict=patient_dict)
         # Flag 1: Pale skin before event
-        input_array[idx, 0] = filter_input.get_flag_value(
-            list_of_keys=BEFORE_EVENT_QUESTIONS,
-            list_of_keywords=FLAG_1_KEYWORDS)
+        input_array[idx, 0] = any([
+            filter_input.get_flag_value(list_of_keys=BEFORE_EVENT_QUESTIONS,
+                                        list_of_keywords=FLAG_1_KEYWORDS),
+            filter_input.get_flag_value(
+                list_of_keys=BEFORE_EVENT_QUESTIONS,
+                list_of_keywords=FLAG_1_KEYWORDS_MULTIPLE,
+                multiple_words_to_match=True)
+        ])
 
         # Flag 3: Fall or slump with loss of awareness
         # during event
@@ -135,9 +150,14 @@ def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
         ])
 
         # Flag 5: Severe preictal headache
-        input_array[idx, 4] = filter_input.get_flag_value(
-            list_of_keys=BEFORE_EVENT_QUESTIONS,
-            list_of_keywords=FLAG_5_KEYWORDS)
+        input_array[idx, 4] = any([
+            filter_input.get_flag_value(list_of_keys=BEFORE_EVENT_QUESTIONS,
+                                        list_of_keywords=FLAG_5_KEYWORDS),
+            filter_input.get_flag_value(
+                list_of_keys=BEFORE_EVENT_QUESTIONS,
+                list_of_keywords=FLAG_5_KEYWORDS_MULTIPLE,
+                multiple_words_to_match=True)
+        ])
 
         # Flag 6: Fall after posture change, standing, coughing, or pain
         input_array[idx, 5] = all([

--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -153,7 +153,6 @@ def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
                             ...
                         }
                     }
-
         Returns:
             np.ndarray: Input array where rows represent each patient, and columns
                 represent each input (i.e. question). Inputs are as follows:

--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -125,7 +125,7 @@ def matches_criteria(
         # Use Spacy's NLP module to generate a list of strings from patient's responses
         input_sentences = " ".join(relevant_responses.values())
         split_words_doc = list(nlp(input_sentences))
-        split_words_lst = set([token.text for token in split_words_doc])
+        split_words_lst = set([token.text.lower() for token in split_words_doc])
 
         # Search for keywords in patient's responses
         matched_criteria.append(search_keywords(split_words_lst, keywords_list))

--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -202,7 +202,7 @@ def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
         if not any(patient_dict.values()):
             input_array[row_idx, :] = np.nan
 
-        for col_idx, keywords_dict in list(KEYWORDS_DICT.items()):
+        for col_idx, keywords_dict in KEYWORDS_DICT.items():
 
             input_array[row_idx, col_idx] = matches_criteria(
                 nlp, patient_dict, keywords_dict

--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -134,12 +134,9 @@ def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
 
         # Flag 2: Loss of consciousness immediately after urination
         # or defacation
-        # Removed due to lack of data
-
-        # Flag 2:
-        input_array[idx, 1] = filter_input.get_flag_value(
-            list_of_keys=DURING_EVENT_QUESTIONS,
-            list_of_keywords=FLAG_2_KEYWORDS)
+        input_array[idx,
+                    1] = filter_input.get_flag_value(DURING_EVENT_QUESTIONS,
+                                                     FLAG_2_KEYWORDS)
 
         # Flag 3: Fall or slump with loss of awareness
         # during event

--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -125,48 +125,42 @@ def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
         filter_input = InputFilter(patient_dict=patient_dict)
         # Flag 1: Pale skin before event
         input_array[idx, 0] = any([
-            filter_input.get_flag_value(list_of_keys=BEFORE_EVENT_QUESTIONS,
-                                        list_of_keywords=FLAG_1_KEYWORDS),
-            filter_input.get_flag_value(
-                list_of_keys=BEFORE_EVENT_QUESTIONS,
-                list_of_keywords=FLAG_1_KEYWORDS_MULTIPLE,
-                multiple_words_to_match=True)
+            filter_input.get_flag_value(BEFORE_EVENT_QUESTIONS,
+                                        FLAG_1_KEYWORDS),
+            filter_input.get_flag_value(BEFORE_EVENT_QUESTIONS,
+                                        FLAG_1_KEYWORDS_MULTIPLE,
+                                        multiple_words_to_match=True)
         ])
 
         # Flag 3: Fall or slump with loss of awareness
         # during event
-        input_array[idx, 2] = filter_input.get_flag_value(
-            list_of_keys=DURING_EVENT_QUESTIONS,
-            list_of_keywords=FLAG_3_KEYWORDS)
+        input_array[idx,
+                    2] = filter_input.get_flag_value(DURING_EVENT_QUESTIONS,
+                                                     FLAG_3_KEYWORDS)
 
         # Flag 4: Seizure with eyes closed lasting longer than 10 minutes
         input_array[idx, 3] = all([
-            filter_input.get_flag_value(
-                list_of_keys=DURING_EVENT_QUESTIONS,
-                list_of_keywords=FLAG_4_KEYWORDS_DURING),
-            filter_input.get_flag_value(
-                list_of_keys=DURATION_QUESTIONS,
-                list_of_keywords=FLAG_4_KEYWORDS_DURATION)
+            filter_input.get_flag_value(DURING_EVENT_QUESTIONS,
+                                        FLAG_4_KEYWORDS_DURING),
+            filter_input.get_flag_value(DURATION_QUESTIONS,
+                                        FLAG_4_KEYWORDS_DURATION)
         ])
 
         # Flag 5: Severe preictal headache
         input_array[idx, 4] = any([
-            filter_input.get_flag_value(list_of_keys=BEFORE_EVENT_QUESTIONS,
-                                        list_of_keywords=FLAG_5_KEYWORDS),
-            filter_input.get_flag_value(
-                list_of_keys=BEFORE_EVENT_QUESTIONS,
-                list_of_keywords=FLAG_5_KEYWORDS_MULTIPLE,
-                multiple_words_to_match=True)
+            filter_input.get_flag_value(BEFORE_EVENT_QUESTIONS,
+                                        FLAG_5_KEYWORDS),
+            filter_input.get_flag_value(BEFORE_EVENT_QUESTIONS,
+                                        FLAG_5_KEYWORDS_MULTIPLE,
+                                        multiple_words_to_match=True)
         ])
 
         # Flag 6: Fall after posture change, standing, coughing, or pain
         input_array[idx, 5] = all([
-            filter_input.get_flag_value(
-                list_of_keys=BEFORE_EVENT_QUESTIONS,
-                list_of_keywords=FLAG_6_KEYWORDS_BEFORE),
-            filter_input.get_flag_value(
-                list_of_keys=DURING_EVENT_QUESTIONS,
-                list_of_keywords=FLAG_6_KEYWORDS_DURING)
+            filter_input.get_flag_value(BEFORE_EVENT_QUESTIONS,
+                                        FLAG_6_KEYWORDS_BEFORE),
+            filter_input.get_flag_value(DURING_EVENT_QUESTIONS,
+                                        FLAG_6_KEYWORDS_DURING)
         ])
 
     input_array = input_array.astype(int)

--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -40,7 +40,7 @@ KEYWORDS_DICT = {
     },
     4: {"before": ["headache", "migraine", ("head", "ache")]},
     5: {"before": ["pain", "cough", "stand"], "during": ["fell", "fall"]},
-}  # TODO: check with MCPV team that format is in str
+}
 
 
 def search_keywords(

--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -2,84 +2,129 @@
 Script of functions to generate predicted and true output matrices.
 """
 
-from typing import List, Mapping, Optional
+from typing import List, Mapping
 
 import numpy as np
 import spacy
 
-BEFORE_EVENT_QUESTIONS = [
-    "What other things do you experience right before or at the beginning of a seizure?",
-    "Please describe what you feel right before or at the beginning of a seizure.",
-    "Please specify other warning."
-    "Which warnings do you get before you have a seizure?",
-]
-DURING_EVENT_QUESTIONS = [
-    "Please specify other symptoms.",
-    "Describe what happens during your seizures.",
-]
-DURATION_QUESTIONS = ["How long do your seizures last?"]
-
-FLAG_1_KEYWORDS = ["pale", "white", "dizzy", "dissy", "vertigo"]
-FLAG_1_KEYWORDS_MULTIPLE = ["light", "head"]
-FLAG_2_KEYWORDS_BEFORE = ["toilet", "restroom"]
-FLAG_2_KEYWORDS_DURING = [
-    "conscious",
-    "fall",
-    "aware",
-    "faint",
-    "blackout",
-]
-FLAG_2_KEYWORDS_DURING_MULTIPLE = ["black", "out"]
-FLAG_3_KEYWORDS = ["collapse", "droop", "slump"]
-FLAG_4_KEYWORDS_DURING = ["eye", "close", "shut"]
-FLAG_4_KEYWORDS_DURATION = [
-    "7 - 15 minutes",
-    "more than 15 minutes",
-]  # TODO: check with MCPV team that format is in str
-FLAG_5_KEYWORDS = ["headache", "migraine"]
-FLAG_5_KEYWORDS_MULTIPLE = ["head", "ache"]
-FLAG_6_KEYWORDS_BEFORE = ["pain", "cough", "stand"]
-FLAG_6_KEYWORDS_DURING = ["fell", "fall"]
+QUESTIONS_DICT = {
+    "before": [
+        "What other things do you experience right before or at the beginning of a seizure?",
+        "Please describe what you feel right before or at the beginning of a seizure.",
+        "Please specify other warning."
+        "Which warnings do you get before you have a seizure?",
+    ],
+    "during": [
+        "Please specify other symptoms.",
+        "Describe what happens during your seizures.",
+    ],
+    "duration": ["How long do your seizures last?"],
+}
 
 
-class InputFilter:
+KEYWORDS_DICT = {
+    0: {
+        "before": ["pale", "white", "dizzy", "dissy", "vertigo", ("light", "head")],
+    },
+    1: {
+        "before": ["toilet", "restroom"],
+        "during": ["conscious", "fall", "aware", "faint", "blackout", ("black", "out")],
+    },
+    2: {"during": ["collapse", "droop", "slump"]},
+    3: {
+        "during": ["eye", "close", "shut"],
+        "duration": [
+            "7 - 15 minutes",
+            "more than 15 minutes",
+        ],
+    },
+    4: {"before": ["headache", "migraine", ("head", "ache")]},
+    5: {"before": ["pain", "cough", "stand"], "during": ["fell", "fall"]},
+}  # TODO: check with MCPV team that format is in str
 
-    nlp = spacy.load("en_core_web_sm")
 
-    def __init__(self, patient_dict):
-        self.patient_dict = patient_dict
+def search_keywords(
+    response_list: List[str],
+    keywords_list: List[str, tuple],
+) -> bool:
+    """Determines if any keywords exist in a list of words.
+    Takes a list of words derived from a patient's response/s and
+    and searches for specific keywords.
 
-    def get_flag_value(
-        self,
-        list_of_keys: List[str],
-        list_of_keywords: List[str],
-        multiple_words_to_match: bool = False,
-    ) -> Optional[bool]:
-        # Filter the patient dict of keys (questions) and values (answers)
-        input_dict = {key: self.patient_dict[key] for key in list_of_keys}
+    In some instances, multiple keywords are required to determine
+    a match, e.g. "black" and "out" in the instance of "black out".
 
-        # Return NaN if no answers provided to key questions
-        input_values = input_dict.values()
-        if not any(input_values):
-            return None
+    Args:
+        response_list: List of words derived from a patient's response/s.
+        keywords_list: List of keywords to match.
 
-        input_sentences = " ".join(input_values)
-        split_words_doc = list(self.nlp(input_sentences))
-        split_words_str = set([token.text for token in split_words_doc])
+    Returns:
+        bool: Returns True if any keywords in list of words, else False.
+    """
+    matched_words = []
 
-        if not multiple_words_to_match:
-            return any(
-                keyword for keyword in list_of_keywords if keyword in split_words_str
-            )
+    for keywords in keywords_list:
+        if type(keywords) == str:
+            matched_words.append([keywords in response_list])
+
         else:
-            return all(
-                keyword for keyword in list_of_keywords if keyword in split_words_str
-            )
+            matched_words.append(all(keyword in response_list for keyword in keywords))
+
+    return any(matched_words)
+
+
+def matches_criteria(
+    nlp: spacy.load,
+    response_dict: Mapping[Mapping[str, str]],
+    keywords_dict: Mapping[str, List[str, tuple]],
+) -> bool:
+    """Determines if a patient's reponse/s fills given criteria for a particular input.
+    Takes dict of a patient's responses and returns True if a patient
+    matches a given set of criteria, and False if the patient does not match a
+    given set of criteria.
+
+    Args:
+    response_dict: A patient's responses to a set of questions. Key-value pairs
+    represent questions and responses.
+        Example: {
+            "Question 1": "Response 1",
+            "Question 2": "Response 2",
+            ...
+        }
+    keywords_dict: A set of criteria required for a given input. Key-value pairs
+    represent an input's criteria category and criteria keywords. The criteria
+    category, e.g. "before" is used to determine which questions from the list of
+    available questions is relevant.
+        Example: {
+            "before": ["toilet", "restroom"],
+            "during": ["conscious", "fall", "aware", "faint", "blackout", ("black", "out")]}
+
+    Returns:
+        bool: Returns True if all criteria is matched, else False.
+    """
+
+    matched_criteria = []
+
+    # Filter response_dict (patient's responses) to relevant questions only
+    for key in keywords_dict.keys():
+        response_dict_filtered = {
+            question: response_dict[question] for question in QUESTIONS_DICT[key]
+        }.values()
+
+        # Use Spacy's NLP module to generate a list of strings from patient's responses
+        input_sentences = " ".join(response_dict_filtered)
+        split_words_doc = list(nlp(input_sentences))
+        split_words_lst = set([token.text for token in split_words_doc])
+
+        # Search for keywords in patient's responses
+        matched_criteria.append(search_keywords(split_words_lst, keywords_dict[key]))
+
+    return all(matched_criteria)
 
 
 def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
     """Takes dictionary of patient's responses to survey questions
-        and transforms to One Hot Encoded matrix."
+    and transforms to One Hot Encoded matrix."
 
         Args:
             input_dict (dict): Dictionary where keys represent a patient,
@@ -129,87 +174,22 @@ def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
                         # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
     """
 
+    nlp = spacy.load("en_core_web_sm")
+
     # Init (transformed) One Hot Encoded input array
     input_array = np.zeros(len(input_dict), 13)
 
-    for idx, patient_dict in enumerate(input_dict.values()):
+    for row_idx, patient_dict in enumerate(input_dict.values()):
 
-        filter_input = InputFilter(patient_dict=patient_dict)
-        # Flag 1: Pale skin before event
-        input_array[idx, 0] = any(
-            [
-                filter_input.get_flag_value(BEFORE_EVENT_QUESTIONS, FLAG_1_KEYWORDS),
-                filter_input.get_flag_value(
-                    BEFORE_EVENT_QUESTIONS,
-                    FLAG_1_KEYWORDS_MULTIPLE,
-                    multiple_words_to_match=True,
-                ),
-            ]
-        )
+        # Set row to np.nan if no responses
+        if not any(patient_dict.values()):
+            input_array[row_idx, :] = np.nan
 
-        # Flag 2: Loss of consciousness immediately after urination or
-        # defecation
-        input_array[idx, 1] = all(
-            [
-                filter_input.get_flag_value(
-                    list_of_keys=BEFORE_EVENT_QUESTIONS,
-                    list_of_keywords=FLAG_2_KEYWORDS_BEFORE,
-                ),
-                any(
-                    filter_input.get_flag_value(
-                        list_of_keys=DURING_EVENT_QUESTIONS,
-                        list_of_keywords=FLAG_2_KEYWORDS_DURING,
-                    ),
-                    filter_input.get_flag_value(
-                        list_of_keys=DURING_EVENT_QUESTIONS,
-                        list_of_keywords=FLAG_2_KEYWORDS_DURING_MULTIPLE,
-                        multiple_words_to_match=True,
-                    ),
-                ),
-            ]
-        )
+        for col_idx, keywords_dict in list(KEYWORDS_DICT.items()):
 
-        # Flag 3: Fall or slump with loss of awareness
-        # during event
-        input_array[idx, 2] = filter_input.get_flag_value(
-            DURING_EVENT_QUESTIONS, FLAG_3_KEYWORDS
-        )
-
-        # Flag 4: Seizure with eyes closed lasting longer than 10 minutes
-        input_array[idx, 3] = all(
-            [
-                filter_input.get_flag_value(
-                    DURING_EVENT_QUESTIONS, FLAG_4_KEYWORDS_DURING
-                ),
-                filter_input.get_flag_value(
-                    DURATION_QUESTIONS, FLAG_4_KEYWORDS_DURATION
-                ),
-            ]
-        )
-
-        # Flag 5: Severe preictal headache
-        input_array[idx, 4] = any(
-            [
-                filter_input.get_flag_value(BEFORE_EVENT_QUESTIONS, FLAG_5_KEYWORDS),
-                filter_input.get_flag_value(
-                    BEFORE_EVENT_QUESTIONS,
-                    FLAG_5_KEYWORDS_MULTIPLE,
-                    multiple_words_to_match=True,
-                ),
-            ]
-        )
-
-        # Flag 6: Fall after posture change, standing, coughing, or pain
-        input_array[idx, 5] = all(
-            [
-                filter_input.get_flag_value(
-                    BEFORE_EVENT_QUESTIONS, FLAG_6_KEYWORDS_BEFORE
-                ),
-                filter_input.get_flag_value(
-                    DURING_EVENT_QUESTIONS, FLAG_6_KEYWORDS_DURING
-                ),
-            ]
-        )
+            input_array[row_idx, col_idx] = matches_criteria(
+                nlp, patient_dict, keywords_dict
+            )
 
     input_array = input_array.astype(int)
 

--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -29,7 +29,7 @@ FLAG_2_KEYWORDS_DURING = [
     "faint",
     "blackout",
 ]
-# TODO: add black + out
+FLAG_2_KEYWORDS_DURING_MULTIPLE = ["black", "out"]
 FLAG_3_KEYWORDS = ["collapse", "droop", "slump"]
 FLAG_4_KEYWORDS_DURING = ["eye", "close", "shut"]
 FLAG_4_KEYWORDS_DURATION = [
@@ -155,9 +155,16 @@ def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
                     list_of_keys=BEFORE_EVENT_QUESTIONS,
                     list_of_keywords=FLAG_2_KEYWORDS_BEFORE,
                 ),
-                filter_input.get_flag_value(
-                    list_of_keys=DURING_EVENT_QUESTIONS,
-                    list_of_keywords=FLAG_2_KEYWORDS_DURING,
+                any(
+                    filter_input.get_flag_value(
+                        list_of_keys=DURING_EVENT_QUESTIONS,
+                        list_of_keywords=FLAG_2_KEYWORDS_DURING,
+                    ),
+                    filter_input.get_flag_value(
+                        list_of_keys=DURING_EVENT_QUESTIONS,
+                        list_of_keywords=FLAG_2_KEYWORDS_DURING_MULTIPLE,
+                        multiple_words_to_match=True,
+                    ),
                 ),
             ]
         )

--- a/src/generate_outputs.py
+++ b/src/generate_outputs.py
@@ -171,27 +171,28 @@ def get_true_output(input_billing_codes: Mapping[str, Sequence[str]]) -> np.ndar
 
     Returns:
         true_output: Output array where rows represent patients and columns represent
-            true diagnosis. Outputs are as follows:
-            output_1 - Non-epileptic paroxysmal event
-            output_2 - Epileptic
-            output_3 - Focal
-            output_4 - Generalized
-            output_5 - Absence
-            output_6 - Myoclonic
-            output_7 - GTCS (Generalized Tonic Clonic Seizures)
+            true diagnosis. Output classes are as follows:
+            Output 1 - Non-epileptic paroxysmal event
+            Output 2 - Epileptic
+            Output 3 - Focal
+            Output 4 - Generalized
+            Output 5 - Absence
+            Output 6 - Myoclonic
+            Output 7 - GTCS (Generalized Tonic Clonic Seizures)
 
             Elements are represented as 0 = negative diagnosis, or 1 = positive diagnosis. N.b. A
             patient may have multiple diagnoses.
-            # Example:
-            # +--------------+----------+-------+-------------+---------+
-            # | non_epilepsy | epilepsy | focal | generalized | unknown |
-            # +--------------+----------+-------+-------------+---------+
-            # | 0            | 0        | 0     | 0           | 0       |
-            # +--------------+----------+-------+-------------+---------+
-            # | 0            | 1        | 1     | 0           | 0       |
-            # +--------------+----------+-------+-------------+---------+
-            # | 0            | 1        | 0     | 1           | 0       |
-            # +--------------+----------+-------+-------------+---------+
+
+            Example:
+                # +--------------+----------+-------+-------------+---------+
+                # | non_epilepsy | epilepsy | focal | generalized | unknown |
+                # +--------------+----------+-------+-------------+---------+
+                # | 0            | 0        | 0     | 0           | 0       |
+                # +--------------+----------+-------+-------------+---------+
+                # | 0            | 1        | 1     | 0           | 0       |
+                # +--------------+----------+-------+-------------+---------+
+                # | 0            | 1        | 0     | 1           | 0       |
+                # +--------------+----------+-------+-------------+---------+
     """
 
     patient_keys = input_billing_codes.keys()


### PR DESCRIPTION
The main purpose of this PR is to enable a search of 'multiple' or 'split' keywords, e.g. "black" and "out" for instances where a free text response may use "black out" instead of "blackout".

This has turned out to be a fairly gnarly code change. This PR does the following:

- adds logic to search for split keywords
   Previously, logic could only handle a keyword of one value. Now, any number of values for a keyword can be searched.
   e.g. "light" and "head". This will match a response which has either "light head" or "light headedness".

- cleans up global variables
   Previously, too many global vars which was difficult to key track of. Instead, two dictionaries are used to specify 
   questions and keywords to match a given criteria.

- cleans up code
   Previously, code was repeated in the main `transform_input()` function, which was also difficult to follow. A for-loop 
   function is now used to iterate over each patient, and each input, and return a bool on whether they have (True) matched 
   criteria or (False) not matched criteria. 