### PR TITLE
Undo removal of Input 2 to avoid confusion and retrieve number of responses

### DIFF
--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -8,27 +8,33 @@ import numpy as np
 import spacy
 
 BEFORE_EVENT_QUESTIONS = [
-    'What other things do you experience right before or at the beginning of a seizure?',
-    'Please describe what you feel right before or at the beginning of a seizure.',
-    'Please specify other warning.'
+    "What other things do you experience right before or at the beginning of a seizure?",
+    "Please describe what you feel right before or at the beginning of a seizure.",
+    "Please specify other warning.",
 ]
 DURING_EVENT_QUESTIONS = [
-    'Please specify other symptoms.',
-    'Describe what happens during your seizures.'
+    "Please specify other symptoms.",
+    "Describe what happens during your seizures.",
 ]
-DURATION_QUESTIONS = ['How long do your seizures last?']
+DURATION_QUESTIONS = ["How long do your seizures last?"]
 
-FLAG_1_KEYWORDS = ['pale', 'white', 'dizzy',
-                   'dissy']  # TODO: add light + head, vertigo multichoice
-FLAG_2_KEYWORDS = ['']
-FLAG_3_KEYWORDS = ['collapse', 'droop', 'slump']
-FLAG_4_KEYWORDS_DURING = ['eye', 'close', 'shut']
+FLAG_1_KEYWORDS = [
+    "pale",
+    "white",
+    "dizzy",
+    "dissy",
+]  # TODO: add light + head, vertigo multichoice
+FLAG_2_KEYWORDS_BEFORE = ["toilet", "restroom"]
+FLAG_2_KEYWORDS_DURING = ["conscious", "fall", "aware", "black"]
+FLAG_3_KEYWORDS = ["collapse", "droop", "slump"]
+FLAG_4_KEYWORDS_DURING = ["eye", "close", "shut"]
 FLAG_4_KEYWORDS_DURATION = [
-    '7 - 15 minutes', 'more than 15 minutes'
+    "7 - 15 minutes",
+    "more than 15 minutes",
 ]  # TODO: check with MCPV team that format is in str
-FLAG_5_KEYWORDS = ['headache', 'migraine']  # TODO: add head + ache
-FLAG_6_KEYWORDS_BEFORE = ['pain', 'cough', 'stand']
-FLAG_6_KEYWORDS_DURING = ['fell', 'fall']
+FLAG_5_KEYWORDS = ["headache", "migraine"]  # TODO: add head + ache
+FLAG_6_KEYWORDS_BEFORE = ["pain", "cough", "stand"]
+FLAG_6_KEYWORDS_DURING = ["fell", "fall"]
 
 
 class InputFilter:
@@ -38,8 +44,9 @@ class InputFilter:
     def __init__(self, patient_dict):
         self.patient_dict = patient_dict
 
-    def get_flag_value(self, list_of_keys: List[str],
-                       list_of_keywords: List[str]) -> Optional[bool]:
+    def get_flag_value(
+        self, list_of_keys: List[str], list_of_keywords: List[str]
+    ) -> Optional[bool]:
         # Filter the patient dict of keys (questions) and values (answers)
         input_dict = {key: self.patient_dict[key] for key in list_of_keys}
 
@@ -48,64 +55,65 @@ class InputFilter:
         if not any(input_values):
             return None
 
-        input_sentences = ' '.join(input_values)
+        input_sentences = " ".join(input_values)
         split_words_doc = list(self.nlp(input_sentences))
         split_words_str = set([token.text for token in split_words_doc])
 
-        return any(keyword for keyword in list_of_keywords
-                   if keyword in split_words_str)
+        return any(
+            keyword for keyword in list_of_keywords if keyword in split_words_str
+        )
 
 
 def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
     """Takes dictionary of patient's responses to survey questions
-    and transforms to One Hot Encoded matrix."
+        and transforms to One Hot Encoded matrix."
 
-    Args:
-        input_dict (dict): Dictionary where keys represent a patient,
-            enclosing another dictionary of key (question), value (answer) pairs.
-            N.b. If no value (answer), to a key (question), an empty string is expected.
-            Example:
-                {
-                    'patient_1': {
-                        'How long do your seizures last?': 'a few seconds',
-                        'Describe what happens during your seizures.': '',
-                        ...
-                    }
-                }
-=
-    Returns:
-        np.ndarray: Input array where rows represent each patient, and columns
-            represent each input (i.e. question). Inputs are as follows:
-                input_1 - Did skin turn pale before event?
-                input_2 - Before event included urination or defacation, AND event included loss of
-                            consciousness.
-                input_3 - Event duration was < 10 sec, AND event included loss of awareness and
-                            fall / slump
-                input_4 - Event duration was > 10 min, AND event included eyes closed
-                input_5 - Before event included severe headache
-                input 6 - Before event included standing up OR sit up OR posture change OR coughing
-                            OR pain, AND event included falling
-                input_7 - Has grey matter lesion (via imaging)
-                input_8 - Event included lip smacking OR chewing
-                input_9 - Events are nocturnal-only
-                input_10 - Onset >= 21 y.o.
-                input_11 - Event duration < 20 sec, AND event included staring OR blank OR unresponsive
-                            OR unaware, AND after event did not include confusion
-                input_12 - Before event excluded resting NOR sleeping AND event included jerks
-                input_13 - Before event included waking w/in 1 hr OR jerking AND event included
-                            convulsions on both sides, stiffening, jerks
-
-                Elements are represented as NaN = no data, 0 = 'no', or 1 = 'yes'.
+        Args:
+            input_dict (dict): Dictionary where keys represent a patient,
+                enclosing another dictionary of key (question), value (answer) pairs.
+                N.b. If no value (answer), to a key (question), an empty string is expected.
                 Example:
-                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
-                    # | flag_1 | flag_2 | flag_3 | flag_4 | flag_5 | flag_6 | lesion | lips | night_seizures | onset_21 | staring | jerks | tonic_clonic |
-                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
-                    # | NaN    | NaN    | NaN    | NaN    | NaN    | NaN    | 1      | 0    | 0              | 0        | 0       | 0     | 0            |
-                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
-                    # | 1      | 1      | 1      | 0      | 0      | 0      | 1      | 0    | 0              | 0        | 0       | 0     | 0            |
-                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
-                    # | 1      | 1      | 1      | 0      | 0      | 0      | 0      | 0    | 0              | 0        | 1       | 1     | 0            |
-                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
+                    {
+                        'patient_1': {
+                            'How long do your seizures last?': 'a few seconds',
+                            'Describe what happens during your seizures.': '',
+                            ...
+                        }
+                    }
+    =
+        Returns:
+            np.ndarray: Input array where rows represent each patient, and columns
+                represent each input (i.e. question). Inputs are as follows:
+                    input_1 - Did skin turn pale before event?
+                    input_2 - Before event included urination or defacation, AND event included loss of
+                                consciousness.
+                    input_3 - Event duration was < 10 sec, AND event included loss of awareness and
+                                fall / slump
+                    input_4 - Event duration was > 10 min, AND event included eyes closed
+                    input_5 - Before event included severe headache
+                    input 6 - Before event included standing up OR sit up OR posture change OR coughing
+                                OR pain, AND event included falling
+                    input_7 - Has grey matter lesion (via imaging)
+                    input_8 - Event included lip smacking OR chewing
+                    input_9 - Events are nocturnal-only
+                    input_10 - Onset >= 21 y.o.
+                    input_11 - Event duration < 20 sec, AND event included staring OR blank OR unresponsive
+                                OR unaware, AND after event did not include confusion
+                    input_12 - Before event excluded resting NOR sleeping AND event included jerks
+                    input_13 - Before event included waking w/in 1 hr OR jerking AND event included
+                                convulsions on both sides, stiffening, jerks
+
+                    Elements are represented as NaN = no data, 0 = 'no', or 1 = 'yes'.
+                    Example:
+                        # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
+                        # | flag_1 | flag_2 | flag_3 | flag_4 | flag_5 | flag_6 | lesion | lips | night_seizures | onset_21 | staring | jerks | tonic_clonic |
+                        # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
+                        # | NaN    | NaN    | NaN    | NaN    | NaN    | NaN    | 1      | 0    | 0              | 0        | 0       | 0     | 0            |
+                        # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
+                        # | 1      | 1      | 1      | 0      | 0      | 0      | 1      | 0    | 0              | 0        | 0       | 0     | 0            |
+                        # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
+                        # | 1      | 1      | 1      | 0      | 0      | 0      | 0      | 0    | 0              | 0        | 1       | 1     | 0            |
+                        # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
     """
 
     # Init (transformed) One Hot Encoded input array
@@ -116,44 +124,52 @@ def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
         filter_input = InputFilter(patient_dict=patient_dict)
         # Flag 1: Pale skin before event
         input_array[idx, 0] = filter_input.get_flag_value(
-            list_of_keys=BEFORE_EVENT_QUESTIONS,
-            list_of_keywords=FLAG_1_KEYWORDS)
+            list_of_keys=BEFORE_EVENT_QUESTIONS, list_of_keywords=FLAG_1_KEYWORDS
+        )
 
         # Flag 2:
         input_array[idx, 1] = filter_input.get_flag_value(
-            list_of_keys=DURING_EVENT_QUESTIONS,
-            list_of_keywords=FLAG_2_KEYWORDS)
+            list_of_keys=DURING_EVENT_QUESTIONS, list_of_keywords=FLAG_2_KEYWORDS
+        )
 
         # Flag 3: Fall or slump with loss of awareness
         # during event
         input_array[idx, 2] = filter_input.get_flag_value(
-            list_of_keys=DURING_EVENT_QUESTIONS,
-            list_of_keywords=FLAG_3_KEYWORDS)
+            list_of_keys=DURING_EVENT_QUESTIONS, list_of_keywords=FLAG_3_KEYWORDS
+        )
 
         # Flag 4: Seizure with eyes closed lasting longer than 10 minutes
-        input_array[idx, 3] = all([
-            filter_input.get_flag_value(
-                list_of_keys=DURING_EVENT_QUESTIONS,
-                list_of_keywords=FLAG_4_KEYWORDS_DURING),
-            filter_input.get_flag_value(
-                list_of_keys=DURATION_QUESTIONS,
-                list_of_keywords=FLAG_4_KEYWORDS_DURATION)
-        ])
+        input_array[idx, 3] = all(
+            [
+                filter_input.get_flag_value(
+                    list_of_keys=DURING_EVENT_QUESTIONS,
+                    list_of_keywords=FLAG_4_KEYWORDS_DURING,
+                ),
+                filter_input.get_flag_value(
+                    list_of_keys=DURATION_QUESTIONS,
+                    list_of_keywords=FLAG_4_KEYWORDS_DURATION,
+                ),
+            ]
+        )
 
         # Flag 5: Severe preictal headache
         input_array[idx, 4] = filter_input.get_flag_value(
-            list_of_keys=BEFORE_EVENT_QUESTIONS,
-            list_of_keywords=FLAG_5_KEYWORDS)
+            list_of_keys=BEFORE_EVENT_QUESTIONS, list_of_keywords=FLAG_5_KEYWORDS
+        )
 
         # Flag 6: Fall after posture change, standing, coughing, or pain
-        input_array[idx, 5] = all([
-            filter_input.get_flag_value(
-                list_of_keys=BEFORE_EVENT_QUESTIONS,
-                list_of_keywords=FLAG_6_KEYWORDS_BEFORE),
-            filter_input.get_flag_value(
-                list_of_keys=DURING_EVENT_QUESTIONS,
-                list_of_keywords=FLAG_6_KEYWORDS_DURING)
-        ])
+        input_array[idx, 5] = all(
+            [
+                filter_input.get_flag_value(
+                    list_of_keys=BEFORE_EVENT_QUESTIONS,
+                    list_of_keywords=FLAG_6_KEYWORDS_BEFORE,
+                ),
+                filter_input.get_flag_value(
+                    list_of_keys=DURING_EVENT_QUESTIONS,
+                    list_of_keywords=FLAG_6_KEYWORDS_DURING,
+                ),
+            ]
+        )
 
     input_array = input_array.astype(int)
 

--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -25,7 +25,13 @@ FLAG_1_KEYWORDS = [
     "dissy",
 ]  # TODO: add light + head, vertigo multichoice
 FLAG_2_KEYWORDS_BEFORE = ["toilet", "restroom"]
-FLAG_2_KEYWORDS_DURING = ["conscious", "fall", "aware", "black"]
+FLAG_2_KEYWORDS_DURING = [
+    "conscious",
+    "fall",
+    "aware",
+    "faint",
+    "blackout",
+]  # TODO: add black + out
 FLAG_3_KEYWORDS = ["collapse", "droop", "slump"]
 FLAG_4_KEYWORDS_DURING = ["eye", "close", "shut"]
 FLAG_4_KEYWORDS_DURATION = [

--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -20,6 +20,7 @@ DURATION_QUESTIONS = ['How long do your seizures last?']
 
 FLAG_1_KEYWORDS = ['pale', 'white', 'dizzy',
                    'dissy']  # TODO: add light + head, vertigo multichoice
+FLAG_2_KEYWORDS = ['']
 FLAG_3_KEYWORDS = ['collapse', 'droop', 'slump']
 FLAG_4_KEYWORDS_DURING = ['eye', 'close', 'shut']
 FLAG_4_KEYWORDS_DURATION = [
@@ -77,7 +78,7 @@ def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
             represent each input (i.e. question). Inputs are as follows:
                 input_1 - Did skin turn pale before event?
                 input_2 - Before event included urination or defacation, AND event included loss of
-                            consciousness. N.b. Removed due to lack of data.
+                            consciousness.
                 input_3 - Event duration was < 10 sec, AND event included loss of awareness and
                             fall / slump
                 input_4 - Event duration was > 10 min, AND event included eyes closed
@@ -96,15 +97,15 @@ def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
 
                 Elements are represented as NaN = no data, 0 = 'no', or 1 = 'yes'.
                 Example:
-                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+-----+
-                    # | flag_1 | flag_3 | flag_4 | flag_5 | flag_6 | lesion | lips | night_seizures | onset_21 | staring | jerks | tonic_clonic |
-                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+-----+
-                    # | NaN    | NaN    | NaN    | NaN    | NaN    | 1      | 0    | 0              | 0        | 0       | 0     | 0            |
-                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+-----+
-                    # | 1      | 1      | 0      | 0      | 0      | 1      | 0    | 0              | 0        | 0       | 0     | 0            |
-                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+-----+
-                    # | 1      | 1      | 0      | 0      | 0      | 0      | 0    | 0              | 0        | 1       | 1     | 0            |
-                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+-----+
+                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
+                    # | flag_1 | flag_2 | flag_3 | flag_4 | flag_5 | flag_6 | lesion | lips | night_seizures | onset_21 | staring | jerks | tonic_clonic |
+                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
+                    # | NaN    | NaN    | NaN    | NaN    | NaN    | NaN    | 1      | 0    | 0              | 0        | 0       | 0     | 0            |
+                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
+                    # | 1      | 1      | 1      | 0      | 0      | 0      | 1      | 0    | 0              | 0        | 0       | 0     | 0            |
+                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
+                    # | 1      | 1      | 1      | 0      | 0      | 0      | 0      | 0    | 0              | 0        | 1       | 1     | 0            |
+                    # +--------+--------+--------+--------+--------+--------+--------+------+----------------+----------+---------+-------+--------------+
     """
 
     # Init (transformed) One Hot Encoded input array
@@ -117,6 +118,11 @@ def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
         input_array[idx, 0] = filter_input.get_flag_value(
             list_of_keys=BEFORE_EVENT_QUESTIONS,
             list_of_keywords=FLAG_1_KEYWORDS)
+
+        # Flag 2:
+        input_array[idx, 1] = filter_input.get_flag_value(
+            list_of_keys=DURING_EVENT_QUESTIONS,
+            list_of_keywords=FLAG_2_KEYWORDS)
 
         # Flag 3: Fall or slump with loss of awareness
         # during event

--- a/src/generate_inputs.py
+++ b/src/generate_inputs.py
@@ -128,8 +128,17 @@ def transform_input(input_dict: Mapping[str, Mapping[str, str]]) -> np.ndarray:
         )
 
         # Flag 2:
-        input_array[idx, 1] = filter_input.get_flag_value(
-            list_of_keys=DURING_EVENT_QUESTIONS, list_of_keywords=FLAG_2_KEYWORDS
+        input_array[idx, 1] = all(
+            [
+                filter_input.get_flag_value(
+                    list_of_keys=BEFORE_EVENT_QUESTIONS,
+                    list_of_keywords=FLAG_2_KEYWORDS_BEFORE,
+                ),
+                filter_input.get_flag_value(
+                    list_of_keys=DURING_EVENT_QUESTIONS,
+                    list_of_keywords=FLAG_2_KEYWORDS_DURING,
+                ),
+            ]
         )
 
         # Flag 3: Fall or slump with loss of awareness


### PR DESCRIPTION
Initially we decided to remove input 2 which mapped to flag 2 in Beniczky's paper, however I think it's best we add input 2 back in as this will allow us to report on statistics of number of responses for publication if required. 

Doing so will also help to avoid confusion in the code, which is always a plus.

Note: Keeping the PRs smaller and chunk-size.