### PR TITLE
Add classification for multiple diagnoses

### DIFF
--- a/src/generate_outputs.py
+++ b/src/generate_outputs.py
@@ -56,6 +56,34 @@ def set_diagnosis(list_of_billing_codes: Sequence[str]) -> np.ndarray:
     return output_row
 
 
+def set_single_diagnosis(output_array: np.ndarray) -> np.ndarray:
+    """Takes the raw output array of diagnoses and sets a single diagnosis
+    (class) per patient, based on diagnostic heirachy.
+    N.b. Sub-epilepsy diagnoses, e.g. focal, etc. are not removed
+    here.
+
+    Args:
+        output_array (np.ndarray): Array of patient diagnoses, with multiple
+            diagnoses per patient.
+
+    Returns:
+        np.ndarray: Array of patient diagnoses, with one diagnosis per patient.
+    """
+    output_array_single_class = output_array.copy()
+
+    for row_idx in range(output_array.shape[0]):
+        row = output_array[row_idx]
+        if np.count_nonzero(row) > 1:
+            if row[0] == 1:
+                raise Exception("Multiple diagnoses set with 'Indeterminate' class.")
+            elif row[2] == 1:
+                output_array_single_class[row_idx, :2] = 0
+            else:
+                raise Exception("Multiple diagnoses mismatch.")
+
+    return output_array_single_class
+
+
 def has_undefined_values(input_array: np.ndarray, threshold: int = 3) -> bool:
     """Counts if number of NaNs in a given array is above a given threshold.
 

--- a/src/run.py
+++ b/src/run.py
@@ -46,12 +46,19 @@ def run(
     # Get input array
     input_array = transform_input(input_data)
 
-    # Run model
-    predicted_output = get_predicted_output(input_array)
+    # Get output array
     true_output = get_true_output(input_billing_codes)
 
+    # Run model
+    predicted_output = get_predicted_output(input_array)
+
     # Get metrics
-    metrics = get_metrics(input_data, predicted_output, true_output, normalize=False)
+    metrics = get_metrics(
+        input_data,
+        predicted_output,
+        true_output,
+        use_single_class=True,
+    )
 
     return
 

--- a/tests/unit/test_outputs.py
+++ b/tests/unit/test_outputs.py
@@ -1,1 +1,16 @@
-# TODO: Add output tests
+class TestGetOutputValues:
+    """Tests functions set_diagnosis(), set_single_diagnosis(),
+    get_predicted_output(), and get_true_output().
+    """
+
+    def test_set_diagnosis(self):
+        return
+
+    def test_set_single_diagnosis(self):
+        return
+
+    def test_get_predicted_output(self):
+        return
+
+    def test_get_true_output(self):
+        return


### PR DESCRIPTION
This PR adds a function into the `get_outputs.py` file that reduces the output array to one diagnosis per patient. The heirachy of diagnosis is epilepsy, following by non-epilepsy.

This is used to calculate the models performance when `use_single_diagnosis` is set to `True` in metrics generation.

Holding off on writing up tests until we receive exact input data from MCP Validate team. 