### PR TITLE
Tighten logic for categorising output diagnosis

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -15,10 +15,10 @@ from typing import Dict, Union
 import numpy as np
 import pandas as pd
 
-from generate_inputs import transform_input
-from generate_outputs import get_predicted_output, get_true_output
-from metrics import get_metrics
-from run_checks import run_checks
+from src.generate_inputs import transform_input
+from src.generate_outputs import get_predicted_output, get_true_output
+from src.metrics import get_metrics
+from src.run_checks import run_checks
 
 
 def read_json(path: str) -> Dict:

--- a/src/run_checks.py
+++ b/src/run_checks.py
@@ -4,7 +4,7 @@ in model."""
 from typing import Any, Dict
 import pandas as pd
 
-from generate_inputs import QUESTIONS_DICT
+from src.generate_inputs import QUESTIONS_DICT
 
 
 def run_checks(input_data: Dict, input_billing_codes: Dict) -> Any:

--- a/tests/unit/test_outputs.py
+++ b/tests/unit/test_outputs.py
@@ -1,1 +1,51 @@
-# TODO: Add output tests
+import numpy as np
+from numpy.testing import assert_array_equal
+import pytest
+from src.generate_outputs import set_diagnosis
+
+
+class TestSetDiagnosis:
+    """Tests function set_diagnosis() to check input diagnoses are
+    correctly categorised in the true output array.
+    Elements are represented as 0 = negative diagnosis, or 1 = positive diagnosis. N.b. A
+    patient may have multiple diagnoses.
+    # Example:
+        # +--------------+--------------+----------+-------+-------------+---------+
+        # indeterminate  | non_epilepsy | epilepsy | focal | generalized | unknown |
+        # +--------------+--------------+----------+-------+-------------+---------+
+        # | 1            | 0            | 0        | 0     | 0           | 0       |
+        # +--------------+--------------+----------+-------+-------------+---------+
+    """
+
+    @pytest.mark.parametrize(
+        "mock_patient_codes, expected_result",
+        [
+            (["R55"], np.array([[0, 1, 0, 0, 0, 0]])),  # Tests syncope for non-epilepsy
+            (
+                ["G43.119"],
+                np.array([[0, 1, 0, 0, 0, 0]]),
+            ),  # Tests paroxysmal for non-epilepsy
+            (
+                ["G40.0"],
+                np.array([[0, 0, 1, 1, 0, 0]]),  # Tests focal for epilepsy
+            ),  # Tests
+            (
+                ["G40.813"],
+                np.array([[0, 0, 1, 0, 0, 1]]),  # Tests unknown for epilepsy
+            ),  # Tests
+            (
+                ["A40.1"],
+                np.array([[1, 0, 0, 0, 0, 0]]),
+            ),  # Tests indeterminate
+            (
+                [],
+                np.array([[1, 0, 0, 0, 0, 0]]),
+            ),  # Tests indeterminate
+        ],
+    )
+    def test_set_diagnosis(self, mock_patient_codes, expected_result):
+        """Tests the function that sets a patient's diagnosis."""
+
+        result = set_diagnosis(patient_codes=mock_patient_codes)
+
+        assert_array_equal(result, expected_result, strict=False)


### PR DESCRIPTION
This PR tightens logic around how to categorise a patient diagnosis based on a list of ICD-10 codes, based on a llist of ICD-10 codes and n of patients has been provided by the Validate team.

```
 Elements are represented as 0 = negative diagnosis, or 1 = positive diagnosis. N.b. A patient may have multiple diagnoses.
            # Example:
                # +--------------+--------------+----------+-------+-------------+---------+
                # indeterminate  | non_epilepsy | epilepsy | focal | generalized | unknown |
                # +--------------+--------------+----------+-------+-------------+---------+
                # | 1            | 0            | 0        | 0     | 0           | 0       |
                # +--------------+--------------+----------+-------+-------------+---------+
                # | 0            | 0            | 1        | 0     | 0           | 0       |
                # +--------------+--------------+----------+-------+-------------+---------+
                # | 0            | 0            | 1        | 0     | 0           | 0       |
                # +--------------+--------------+----------+-------+-------------+---------+
```

CHANGES:
`generate_outputs.py`: 
- added billing codes
- added logic to check if billing code `startswith()`
- increased n of cols to 6, to reflect new matrix size
- modified logic to assign the correct diagnosis column

N.b. If a patient's ICD10 code does not match, the patient row will be assigned 'indeterminate'. In future, an error may be raised.

TESTING:
`test_generate_outputs.py`
- unit for function `set_diagnosis()` added to test suite

Currently, these changes DO NOT reflect a patient that has multiple diagnoses. Confirmation is required from Validate team.