### PR TITLE
Update logic for predicted output

### DIFF
--- a/src/generate_outputs.py
+++ b/src/generate_outputs.py
@@ -85,14 +85,14 @@ def has_undefined_values(input_array: np.ndarray, threshold: int = 3) -> bool:
     return np.count_nonzero(np.isnan(input_array)) > threshold
 
 
-def has_positive_values(input_array: np.ndarray, threshold: int = 0) -> bool:
-    """Checks if an array has enough non-zero data given a threshold.
+def has_positive_values(input_array: np.ndarray) -> bool:
+    """Checks if an array has at least one '1' value.
 
     Returns:
         bool: Returns True if n of non-zero elements exceeds threshold, and False if
                 n of non-zero elements does not exceed threshold.
     """
-    return np.count_nonzero(input_array) > threshold
+    return np.nansum(input_array) > 0
 
 
 def get_predicted_output(input_array: np.ndarray) -> np.ndarray:
@@ -132,20 +132,16 @@ def get_predicted_output(input_array: np.ndarray) -> np.ndarray:
     predicted_output = np.zeros((n_rows, 6))
     for idx in range(n_rows):
         row = input_array[idx, :]
-
-        # No data
-        if has_undefined_values(row, threshold=1):
-            predicted_output[idx, 0] = 1
-        # Indeterminate
-        elif has_undefined_values(row, threshold=3):
+        # Indeterminate (i.e. not enough data)
+        if has_undefined_values(row, threshold=3):
             predicted_output[idx, 0] = 1
         # Epilepsy vs Non-epilepsy
-        elif has_positive_values(row, 2):
+        elif has_positive_values(row):
+            # Non-Epilepsy
+            predicted_output[idx, 1] = 1
+        else:
             # Epilepsy
             predicted_output[idx, 2] = 1
-        else:
-            # Non-epilepsy
-            predicted_output[idx, 1] = 1
 
     return predicted_output
 

--- a/tests/data/test_billing_codes.json
+++ b/tests/data/test_billing_codes.json
@@ -1,5 +1,7 @@
 {
   "patient_1": ["R55"],
   "patient_2": ["R55"],
-  "patient_3": ["G40.8"]
+  "patient_3": ["G40.8"],
+  "patient_4": ["F44.5"],
+  "patient_5": ["G40.0"]
 }

--- a/tests/data/test_responses.json
+++ b/tests/data/test_responses.json
@@ -37,5 +37,31 @@
     "Please describe what other symptoms you have.": "",
     "What other things happen to you during your seizure?": "",
     "What injuries have you experienced during a seizure?": ""
+  },
+  "patient_4": {
+    "What other things do you experience right before or at the beginning of a seizure?": "I get a headache and somtimes a bit dizzy!",
+    "Please describe what you feel right before or at the beginning of a seizure.": "Usually when I go to the toilet.",
+    "Please specify other warning.": "",
+    "Please specify other injuries.": "",
+    "Which warnings do you get before you have a seizure?": "",
+    "Please specify other symptoms.": "",
+    "Describe what happens during your seizures.": "Blacking out.",
+    "How long do your seizures last?": "",
+    "Please describe what other symptoms you have.": "",
+    "What other things happen to you during your seizure?": "",
+    "What injuries have you experienced during a seizure?": ""
+  },
+  "patient_5": {
+    "What other things do you experience right before or at the beginning of a seizure?": "",
+    "Please describe what you feel right before or at the beginning of a seizure.": "",
+    "Please specify other warning.": "I don't have any.",
+    "Please specify other injuries.": "I don't get injured.",
+    "Which warnings do you get before you have a seizure?": "None.",
+    "Please specify other symptoms.": "",
+    "Describe what happens during your seizures.": "",
+    "How long do your seizures last?": "",
+    "Please describe what other symptoms you have.": "",
+    "What other things happen to you during your seizure?": "",
+    "What injuries have you experienced during a seizure?": ""
   }
 }

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -24,20 +24,42 @@ class TestEndToEnd:
         metrics = read_json(os.path.join(TEST_OUTPUT_DIR, "metrics.json"))
 
         expected_input_array = np.array(
-            ([np.nan] * 6, [0, 0, 0, np.nan, 0, 0], [1, 1, 0, np.nan, 1, 0])
+            (
+                [np.nan] * 6,
+                [0, 0, 0, np.nan, 0, 0],
+                [1, 1, 0, np.nan, 1, 0],
+                [1, 1, 0, np.nan, 1, 0],
+                [0, 0, 0, np.nan, 0, 0],
+            )
         )
         expected_pred_output = np.array(
-            ([[1, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0], [0, 0, 1, 0, 0, 0]])
+            (
+                [
+                    [1, 0, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 0],
+                    [0, 1, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 0],
+                ]
+            )
         )
         expected_true_output = np.array(
-            ([[0, 1, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0], [0, 0, 1, 0, 0, 1]])
+            (
+                [
+                    [0, 1, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 1],
+                    [0, 1, 0, 0, 0, 0],
+                    [0, 0, 1, 1, 0, 0],
+                ]
+            )
         )
 
         expected_metrics = {
             "Name": "Evaluation 1",
             "Description": "Metrics for Epilepsy vs Non-Epilepsy classes.",
             "Summary": {
-                "total": {"predicted": 3.0, "true": 3.0},
+                "total": {"predicted": 5.0, "true": 5.0},
                 "total_classes": {
                     "predicted": 6.0,
                     "true": 6.0,
@@ -48,57 +70,56 @@ class TestEndToEnd:
                 "inputs": {
                     "0": {
                         "indeterminate": {"0": 0, "1": 0, "NaN": 0},
-                        "non_epilepsy": {"0": 1, "1": 0, "NaN": 1},
-                        "epilepsy": {"0": 0, "1": 1, "NaN": 0},
+                        "non_epilepsy": {"0": 1, "1": 1, "NaN": 1},
+                        "epilepsy": {"0": 1, "1": 1, "NaN": 0},
                     },
                     "1": {
                         "indeterminate": {"0": 0, "1": 0, "NaN": 0},
-                        "non_epilepsy": {"0": 1, "1": 0, "NaN": 1},
-                        "epilepsy": {"0": 0, "1": 1, "NaN": 0},
+                        "non_epilepsy": {"0": 1, "1": 1, "NaN": 1},
+                        "epilepsy": {"0": 1, "1": 1, "NaN": 0},
                     },
                     "2": {
                         "indeterminate": {"0": 0, "1": 0, "NaN": 0},
-                        "non_epilepsy": {"0": 1, "1": 0, "NaN": 1},
-                        "epilepsy": {"0": 1, "1": 0, "NaN": 0},
+                        "non_epilepsy": {"0": 2, "1": 0, "NaN": 1},
+                        "epilepsy": {"0": 2, "1": 0, "NaN": 0},
                     },
                     "3": {
                         "indeterminate": {"0": 0, "1": 0, "NaN": 0},
-                        "non_epilepsy": {"0": 0, "1": 0, "NaN": 2},
-                        "epilepsy": {"0": 0, "1": 0, "NaN": 1},
+                        "non_epilepsy": {"0": 0, "1": 0, "NaN": 3},
+                        "epilepsy": {"0": 0, "1": 0, "NaN": 2},
                     },
                     "4": {
                         "indeterminate": {"0": 0, "1": 0, "NaN": 0},
-                        "non_epilepsy": {"0": 1, "1": 0, "NaN": 1},
-                        "epilepsy": {"0": 0, "1": 1, "NaN": 0},
+                        "non_epilepsy": {"0": 1, "1": 1, "NaN": 1},
+                        "epilepsy": {"0": 1, "1": 1, "NaN": 0},
                     },
                     "5": {
                         "indeterminate": {"0": 0, "1": 0, "NaN": 0},
-                        "non_epilepsy": {"0": 1, "1": 0, "NaN": 1},
-                        "epilepsy": {"0": 1, "1": 0, "NaN": 0},
+                        "non_epilepsy": {"0": 2, "1": 0, "NaN": 1},
+                        "epilepsy": {"0": 2, "1": 0, "NaN": 0},
                     },
                 },
                 "diagnoses": {
                     "predicted": {
                         "indeterminate": 1.0,
-                        "non_epilepsy": 1.0,
-                        "epilepsy": 1.0,
+                        "non_epilepsy": 2.0,
+                        "epilepsy": 2.0,
                     },
                     "true": {
                         "indeterminate": 0.0,
-                        "non_epilepsy": 2.0,
-                        "epilepsy": 1.0,
+                        "non_epilepsy": 3.0,
+                        "epilepsy": 2.0,
                     },
                 },
             },
             "Performance": {
                 "accuracy": {
-                    "total": 1.0,
+                    "total": 2.0,
                     "percentage": 0.5,
                 },
                 "accuracy_balanced": {"total": 0.5},
             },
         }
-
         np.testing.assert_array_equal(input_array, expected_input_array)
         np.testing.assert_array_equal(true_output, expected_true_output)
         np.testing.assert_array_equal(pred_output, expected_pred_output)

--- a/tests/unit/test_inputs.py
+++ b/tests/unit/test_inputs.py
@@ -76,7 +76,7 @@ class TestTransformInput:
         [
             (
                 pytest.lazy_fixture("patient_7_dict"),
-                [1, 1, 0, 0, 1, 0],
+                [1, 1, 0, np.nan, 1, 0],
             ),  # Tests for flags 1, 2, and 5
         ],
     )

--- a/tests/unit/test_outputs.py
+++ b/tests/unit/test_outputs.py
@@ -1,5 +1,4 @@
 import numpy as np
-from numpy.testing import assert_array_equal
 import pytest
 from src.generate_outputs import set_diagnosis
 
@@ -48,4 +47,4 @@ class TestSetDiagnosis:
 
         result = set_diagnosis(patient_codes=mock_patient_codes)
 
-        assert_array_equal(result, expected_result, strict=False)
+        np.testing.assert_array_equal(result, expected_result)


### PR DESCRIPTION
This PR updates logic for the predicted output such that only one criteria need to be met in order to determine non-epilepsy.

Also fixes issue where a red flag of '1' determines non-epilepsy, rather than epilepsy (see to Beniczky model).

All tests are updated.